### PR TITLE
feat: add `IsTorsionlessStrip` method

### DIFF
--- a/doc/ChStripsSyzygies.xml
+++ b/doc/ChStripsSyzygies.xml
@@ -41,6 +41,8 @@
   <#Include Label="DocIsIndecProjectiveStrip">
   
   <#Include Label="DocIsIndecInjectiveStrip">
+
+  <#Include Label="DocIsTorsionlessStrip">
 </Section>
 
 <Section>

--- a/lib/strips.gd
+++ b/lib/strips.gd
@@ -770,3 +770,17 @@ DeclareOperation(
  "DeloopingLevelOfSBAlgIfAtMostN",
  [ IsSpecialBiserialAlgebra, IsInt ]
  );
+
+##  <#GAPDoc Label="DocIsTorsionlessStrip">
+##    <ManSection>
+##      <Prop Name="IsTorsionlessStrip" Arg="strip"/>
+##      <Description>
+##        Arguments: <A>strip</A>, a strip.
+##        <Br />
+##      </Description>
+##      <Returns>
+##        &true; if <A>strip</A> represents a torsionless module, and &false; otherwise.
+##      </Returns>
+##    </ManSection>
+##  <#/GAPDoc>
+DeclareProperty( "IsTorsionlessStrip", IsStripRep );

--- a/lib/strips.gi
+++ b/lib/strips.gi
@@ -129,7 +129,7 @@ InstallOtherMethod(
             if ( sy_list1 = sy_list2 ) and ( ori_list1 = ori_list2 ) then
                 return true;
             elif ( sy_list1 = Reversed( sy_list2 ) ) and
-             ( sy_list1 = Reversed( sy_list2 ) ) then
+             ( ori_list1 = Reversed( ori_list2 ) ) then
                 return true;
             else
                 return false;

--- a/lib/strips.gi
+++ b/lib/strips.gi
@@ -3298,3 +3298,22 @@ RedispatchOnCondition(
     [ IsSpecialBiserialAlgebra,  ],
     0
 );
+
+InstallMethod(
+    IsTorsionlessStrip,
+    "for a strip-rep",
+    [ IsStripRep ],
+    function( strip )
+        local
+            del0;    # Defining SB algebra of <strip>
+
+        if HasIsTorsionlessStrip( strip ) then
+            return IsTorsionlessStrip( strip );
+
+        else
+            del0 := DeloopingLevelOfStripIfAtMostN( strip, 0 );
+
+            return del0 = 0;
+        fi;
+    end
+);


### PR DESCRIPTION
Adds a method for checking if a strip represents a torsionless module.
(This relies on the fact that torsionless modules are exactly those with delooping level 0).

Also includes a quick fix of a typo in the method for checking if strips are equal.