### PR TITLE
feat: helper functions for creating 1-regular, 2-regular and sub-2-regular quivers

### DIFF
--- a/lib/1reg.gd
+++ b/lib/1reg.gd
@@ -131,4 +131,4 @@ DeclareProperty( "Is2RegQuiver", IsQuiver );
 ##    </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
-DeclareGlobalFunction( "1RegQuivFromCycleLengths", IsList );
+DeclareOperation( "1RegQuivFromCycleLengths", [ IsList ] );

--- a/lib/1reg.gd
+++ b/lib/1reg.gd
@@ -112,3 +112,23 @@ DeclareOperation( "PathByTargetAndLength", [ IsQuiverVertex, IsInt ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 DeclareProperty( "Is2RegQuiver", IsQuiver );
+
+##  <#GAPDoc Label="Doc1RegQuivFromCycleLengths">
+##  <ManSection>
+##    <Prop Name="1RegQuivFromCycleLengths" Arg="cycle_lengths"/>
+##    <Description>
+##      Argument: <A>cycle_lengths</A>, a list of integers
+##      <Br />
+##    </Description>
+##    <Returns>
+##      a <M>1</M>-regular quiver with cycles of the given lengths.
+##    </Returns>
+##    <Description>
+##      The vertices are named sequentially ("v1", "v2", ...) within each cycle
+##      and then in order of the cycles as given by the cycle lengths
+##      The arrows ("a1", "a2", ...) are named such that their number corresponds
+##      to the number of their source (i.e. the source of "a3" is "v3").
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+DeclareGlobalFunction( "1RegQuivFromCycleLengths", IsList );

--- a/lib/1reg.gi
+++ b/lib/1reg.gi
@@ -164,3 +164,42 @@ InstallMethod(
          );
     end
 );
+
+InstallGlobalFunction(
+    1RegQuivFromCycleLengths,
+    "for a list of positive integers",
+    function( cycle_lengths )
+        local
+            vertices,   # list of vertices
+            arrows,     # list of arrows
+            i,          # loop variable for names of vertices and arrows
+            len,        # loop variable for the length of each of the cycles
+            j,          # loop variable for vertices in a cycle
+            Q;          # output quiver
+
+        if not ForAll( cycle_lengths, IsPosInt ) then
+            TryNextMethod();
+        fi;
+
+        vertices := [];
+        arrows := [];
+
+        i := 0;
+        for len in cycle_lengths do
+            for j in [ 1 .. len ] do
+                Add( vertices, Concatenation( "v", String( i + j ) ) );
+                Add( arrows, [ Concatenation( "v", String( i + j ) ),
+                               Concatenation( "v", String( ( j mod len ) + i + 1 ) ),
+                               Concatenation( "a", String( i + j ) )
+                ] );
+            od;
+            i := i + len;
+        od;
+
+        Q := Quiver( vertices, arrows );
+        # If this assertion fails then something very weird has gone wrong
+        Assert( 1, Is1RegQuiver(Q), "Constructed quiver is not 1-regular" );
+
+        return Q;
+    end
+);

--- a/lib/1reg.gi
+++ b/lib/1reg.gi
@@ -165,9 +165,10 @@ InstallMethod(
     end
 );
 
-InstallGlobalFunction(
+InstallMethod(
     1RegQuivFromCycleLengths,
     "for a list of positive integers",
+    [ IsList ],
     function( cycle_lengths )
         local
             vertices,   # list of vertices

--- a/lib/overquiver.gi
+++ b/lib/overquiver.gi
@@ -568,7 +568,7 @@ InstallMethod(
             #  <OverquiverOfSBAlg> command. Such quivers have this property set
             #  (to <true>) at creation. Therefore any quiver for which this
             #  property has not been set must not have been so constructed.
-            return fail;
+            return false;
         fi;
     end
 );

--- a/lib/util.gd
+++ b/lib/util.gd
@@ -390,9 +390,14 @@ DeclareAttribute( "PathOneArrowShorterAtTarget", IsPath );
 ##        the quiver obtained from <A>quiver</A> when you identify all vertices in each entry
 ##        of <A>parts</A>
 ##      </Returns>
+##      <Description>
+##        Also attaches information about the quotient quiver to the input quiver.
+##      </Description>
 ##    </ManSection>
 ##  <#/GAPDoc>
 DeclareOperation( "QuiverQuotient", [ IsQuiver, IsList ] );
+DeclareAttribute( "IsCoveringQuiver", IsQuiver );
+DeclareAttribute( "IsQuotientQuiver", IsQuiver );
 
 ##  <#GAPDoc Label="DocQuiverFilterArrows">
 ##    <ManSection>

--- a/lib/util.gd
+++ b/lib/util.gd
@@ -374,3 +374,22 @@ DeclareAttribute( "PathOneArrowLongerAtSource", IsPath );
 DeclareAttribute( "PathOneArrowLongerAtTarget", IsPath );
 DeclareAttribute( "PathOneArrowShorterAtSource", IsPath );
 DeclareAttribute( "PathOneArrowShorterAtTarget", IsPath );
+
+##  <#GAPDoc Label="DocQuotientQuiver">
+##    <ManSection>
+##      <Oper Name="QuotientQuiver" Arg="quiver, parts"/>
+##      <Description>
+##        Arguments: <A>quiver</A>, a quiver;
+##                  <A>parts</A> a list where each entry is a sublist of the vertices
+##                  of <A>quiver</A>, and the union of the entries is a list of all vertices of
+##                  <A>quiver</A> (i.e. <A>parts</A> is a partition of the vertices
+##                  of <A>quiver</A>).
+##        <Br />
+##      </Description>
+##      <Returns>
+##        the quiver obtained from <A>quiver</A> when you identify all vertices in each entry
+##        of <A>parts</A>
+##      </Returns>
+##    </ManSection>
+##  <#/GAPDoc>
+DeclareOperation( "QuotientQuiver", [IsQuiver, IsList] );

--- a/lib/util.gd
+++ b/lib/util.gd
@@ -393,3 +393,20 @@ DeclareAttribute( "PathOneArrowShorterAtTarget", IsPath );
 ##    </ManSection>
 ##  <#/GAPDoc>
 DeclareOperation( "QuotientQuiver", [IsQuiver, IsList] );
+
+##  <#GAPDoc Label="DocQuiverFilterArrows">
+##    <ManSection>
+##      <Oper Name="QuiverFilterArrows" Arg="quiver, fn"/>
+##      <Description>
+##        Arguments: <A>quiver</A>, a quiver;
+##                  <A>fn</A> a function that returns boolean values when evaluated on
+##                  arrows of <A>quiver</A>
+##        <Br />
+##      </Description>
+##      <Returns>
+##        the quiver obtained from <A>quiver</A> when you remove all vertices that return
+##        <A>false</A> when we apply <A>fn</A> to it.
+##      </Returns>
+##    </ManSection>
+##  <#/GAPDoc>
+DeclareOperation( "QuiverFilterArrows", [ IsQuiver, IsFunction ] );

--- a/lib/util.gd
+++ b/lib/util.gd
@@ -375,9 +375,9 @@ DeclareAttribute( "PathOneArrowLongerAtTarget", IsPath );
 DeclareAttribute( "PathOneArrowShorterAtSource", IsPath );
 DeclareAttribute( "PathOneArrowShorterAtTarget", IsPath );
 
-##  <#GAPDoc Label="DocQuotientQuiver">
+##  <#GAPDoc Label="DocQuiverQuotient">
 ##    <ManSection>
-##      <Oper Name="QuotientQuiver" Arg="quiver, parts"/>
+##      <Oper Name="QuiverQuotient" Arg="quiver, parts"/>
 ##      <Description>
 ##        Arguments: <A>quiver</A>, a quiver;
 ##                  <A>parts</A> a list where each entry is a sublist of the vertices
@@ -392,7 +392,7 @@ DeclareAttribute( "PathOneArrowShorterAtTarget", IsPath );
 ##      </Returns>
 ##    </ManSection>
 ##  <#/GAPDoc>
-DeclareOperation( "QuotientQuiver", [ IsQuiver, IsList ] );
+DeclareOperation( "QuiverQuotient", [ IsQuiver, IsList ] );
 
 ##  <#GAPDoc Label="DocQuiverFilterArrows">
 ##    <ManSection>

--- a/lib/util.gd
+++ b/lib/util.gd
@@ -392,7 +392,7 @@ DeclareAttribute( "PathOneArrowShorterAtTarget", IsPath );
 ##      </Returns>
 ##    </ManSection>
 ##  <#/GAPDoc>
-DeclareOperation( "QuotientQuiver", [IsQuiver, IsList] );
+DeclareOperation( "QuotientQuiver", [ IsQuiver, IsList ] );
 
 ##  <#GAPDoc Label="DocQuiverFilterArrows">
 ##    <ManSection>

--- a/lib/util.gi
+++ b/lib/util.gi
@@ -644,6 +644,7 @@ InstallMethod(
             arrows,     # list of arrows of constructed quiver
             p,          # loop variable for classes of the partition
             a,          # loop variable for arrows of input quiver
+            v,          # loop variable for vertices of input quiver
             find_class, # helper function for finding partition class of vertex
             s, t,       # ends of an arrow in construction loop
             quot;
@@ -682,7 +683,55 @@ InstallMethod(
 
         quot := Quiver( vertices, arrows );
 
+        for v in VerticesOfQuiver( quiver ) do
+            v!.LiftOf := quot.( Concatenation( "v", String( find_class( v ) ) ) );
+        od;
+
+        for a in ArrowsOfQuiver( quiver ) do
+            a!.LiftOf := quot.( String( a ) );
+        od;
+
+        SetIsCoveringQuiver( quiver, true );
+        quiver!.quotient := quot;
+        SetIsQuotientQuiver( quot, true );
+        quot!.covering := quiver;
+
         return quot;
+    end
+);
+
+InstallMethod(
+    IsCoveringQuiver,
+    "for quivers",
+    [ IsQuiver ],
+    function( quiver )
+        if HasIsCoveringQuiver( quiver ) then
+            return IsCoveringQuiver( quiver );
+        else
+            # Covering quivers are exactly those quivers that have been
+            #  inputted to the <QuiverQuotient> command. Such quivers have
+            #  this property set (to <true>) at creation. Therefore any quiver
+            #  for which this property has not been set must not have been so
+            #  inputted.
+            return false;
+        fi;
+    end
+);
+
+InstallMethod(
+    IsQuotientQuiver,
+    "for quivers",
+    [ IsQuiver ],
+    function( quiver )
+        if HasIsQuotientQuiver( quiver ) then
+            return IsQuotientQuiver( quiver );
+        else
+            # Quotient quivers are exactly those quivers constructed using the
+            #  <QuiverQuotient> command. Such quivers have this property set
+            #  (to <true>) at creation. Therefore any quiver for which this
+            #  property has not been set must not have been so constructed.
+            return false;
+        fi;
     end
 );
 

--- a/lib/util.gi
+++ b/lib/util.gi
@@ -635,7 +635,7 @@ InstallMethod(
 );
 
 InstallMethod(
-    QuotientQuiver,
+    QuiverQuotient,
     "for a quiver and a partition of its vertices",
     [ IsQuiver, IsList ],
     function( quiver, parts)

--- a/lib/util.gi
+++ b/lib/util.gi
@@ -633,3 +633,54 @@ InstallMethod(
         fi;
     end
 );
+
+InstallMethod(
+    QuotientQuiver,
+    "for a quiver and a partition of its vertices",
+    [ IsQuiver, IsList ],
+    function( quiver, parts)
+        local
+            vertices,   # list of vertices of constructed quiver
+            arrows,     # list of arrows of constructed quiver
+            p,          # loop variable for classes of the partition
+            a,          # loop variable for arrows of input quiver
+            find_class, # helper function for finding partition class of vertex
+            s, t;       # ends of an arrow in construction loop
+
+        if not ForAll(parts, IsList) then
+            Error( "The second argument\n", parts, "\nmust be a list of lists of vertices",
+             "of the quiver\n", quiver );
+        elif Set(Flat(parts)) <> Set(VerticesOfQuiver(quiver)) then
+            Error( "The second argument\n", parts, "\nmust include all vertices ",
+             "of the quiver\n", quiver );
+        elif Length(Flat(parts)) <> NumberOfVertices(quiver) then
+            Error( "The second argument\n", parts, "\nmust include all vertices ",
+             "of the quiver\n", quiver );
+        fi;
+
+        vertices := List([1..Length(parts)], i -> Concatenation("v", String(i)));
+
+        find_class := function(vertex)
+            local i;
+            i := 1;
+            while i <= Length(parts) do
+                if vertex in parts[i] then
+                    return i;
+                fi;
+                i := i + 1;
+            od;
+            return fail;
+        end;
+
+        arrows := [];
+        for a in ArrowsOfQuiver(quiver) do
+            s := Concatenation("v", String(find_class(SourceOfPath(a))));
+            t := Concatenation("v", String(find_class(TargetOfPath(a))));
+            Add(arrows, [s, t, String(a)]);
+        od;
+
+        quot := Quiver(vertices, arrows);
+
+        return quot;
+    end
+);

--- a/lib/util.gi
+++ b/lib/util.gi
@@ -645,7 +645,8 @@ InstallMethod(
             p,          # loop variable for classes of the partition
             a,          # loop variable for arrows of input quiver
             find_class, # helper function for finding partition class of vertex
-            s, t;       # ends of an arrow in construction loop
+            s, t,       # ends of an arrow in construction loop
+            quot;
 
         if not ForAll( parts, IsList ) then
             Error( "The second argument\n", parts, "\nmust be a list of lists of vertices",

--- a/lib/util.gi
+++ b/lib/util.gi
@@ -647,24 +647,24 @@ InstallMethod(
             find_class, # helper function for finding partition class of vertex
             s, t;       # ends of an arrow in construction loop
 
-        if not ForAll(parts, IsList) then
+        if not ForAll( parts, IsList ) then
             Error( "The second argument\n", parts, "\nmust be a list of lists of vertices",
              "of the quiver\n", quiver );
-        elif Set(Flat(parts)) <> Set(VerticesOfQuiver(quiver)) then
+        elif Set( Flat( parts ) ) <> Set( VerticesOfQuiver( quiver ) ) then
             Error( "The second argument\n", parts, "\nmust include all vertices ",
              "of the quiver\n", quiver );
-        elif Length(Flat(parts)) <> NumberOfVertices(quiver) then
+        elif Length( Flat( parts ) ) <> NumberOfVertices( quiver ) then
             Error( "The second argument\n", parts, "\nmust include all vertices ",
              "of the quiver\n", quiver );
         fi;
 
-        vertices := List([1..Length(parts)], i -> Concatenation("v", String(i)));
+        vertices := List( [ 1..Length( parts ) ], i -> Concatenation( "v", String( i ) ) );
 
-        find_class := function(vertex)
+        find_class := function( vertex )
             local i;
             i := 1;
-            while i <= Length(parts) do
-                if vertex in parts[i] then
+            while i <= Length( parts ) do
+                if vertex in parts[ i ] then
                     return i;
                 fi;
                 i := i + 1;
@@ -672,14 +672,14 @@ InstallMethod(
             return fail;
         end;
 
-        arrows := [];
-        for a in ArrowsOfQuiver(quiver) do
-            s := Concatenation("v", String(find_class(SourceOfPath(a))));
-            t := Concatenation("v", String(find_class(TargetOfPath(a))));
-            Add(arrows, [s, t, String(a)]);
+        arrows := [ ];
+        for a in ArrowsOfQuiver( quiver ) do
+            s := Concatenation( "v", String( find_class( SourceOfPath( a ) ) ) );
+            t := Concatenation( "v", String( find_class( TargetOfPath( a ) ) ) );
+            Add( arrows, [ s, t, String( a ) ] );
         od;
 
-        quot := Quiver(vertices, arrows);
+        quot := Quiver( vertices, arrows );
 
         return quot;
     end
@@ -689,15 +689,15 @@ InstallMethod(
     QuiverFilterArrows,
     "for a quiver and a partition of its vertices",
     [ IsQuiver, IsFunction ],
-    function(quiver, fn)
+    function( quiver, fn )
         local
             vertices,
             arrows;
 
-        vertices := List(VerticesOfQuiver(quiver), x -> String(x));
-        arrows := Filtered(ArrowsOfQuiver(quiver), x -> fn(x));
-        arrows := List(arrows, x -> [String(SourceOfPath(x)), String(TargetOfPath(x)), String(x)]);
+        vertices := List( VerticesOfQuiver( quiver ), x -> String( x ));
+        arrows := Filtered( ArrowsOfQuiver( quiver ), x -> fn( x ));
+        arrows := List( arrows, x -> [ String( SourceOfPath( x )), String( TargetOfPath( x )), String( x ) ] );
 
-        return Quiver(vertices, arrows);
+        return Quiver( vertices, arrows );
     end
 );

--- a/lib/util.gi
+++ b/lib/util.gi
@@ -684,3 +684,20 @@ InstallMethod(
         return quot;
     end
 );
+
+InstallMethod(
+    QuiverFilterArrows,
+    "for a quiver and a partition of its vertices",
+    [ IsQuiver, IsFunction ],
+    function(quiver, fn)
+        local
+            vertices,
+            arrows;
+
+        vertices := List(VerticesOfQuiver(quiver), x -> String(x));
+        arrows := Filtered(ArrowsOfQuiver(quiver), x -> fn(x));
+        arrows := List(arrows, x -> [String(SourceOfPath(x)), String(TargetOfPath(x)), String(x)]);
+
+        return Quiver(vertices, arrows);
+    end
+);

--- a/tst/testall.tst
+++ b/tst/testall.tst
@@ -355,11 +355,11 @@ gap> for k in [ 1 .. NumberOfVertices( Q2 ) / 2 ] do
 >   Add( parts2, VerticesOfQuiver( Q2 ){ [ k, NumberOfVertices( Q2 ) - k + 1 ] } );
 >   Add( parts3, VerticesOfQuiver( Q2 ){ [ k, NumberOfVertices( Q2 ) / 2 + k ] } );
 > od;
-gap> Q2reg1 := QuotientQuiver( Q2, parts1 );
+gap> Q2reg1 := QuiverQuotient( Q2, parts1 );
 <quiver with 7 vertices and 14 arrows>
-gap> Q2reg2 := QuotientQuiver( Q2, parts2 );
+gap> Q2reg2 := QuiverQuotient( Q2, parts2 );
 <quiver with 7 vertices and 14 arrows>
-gap> Q2reg3 := QuotientQuiver( Q2, parts3 );
+gap> Q2reg3 := QuiverQuotient( Q2, parts3 );
 <quiver with 7 vertices and 14 arrows>
 gap> Is2RegQuiver( Q2reg1 );
 true

--- a/tst/testall.tst
+++ b/tst/testall.tst
@@ -324,5 +324,37 @@ gap> Recollected( hello_world );
 [ [ "e", 1 ], [ "h", 1 ], [ "l", 3 ], [ "o", 2 ], [ "d", 1 ],
 [ "r", 1 ], [ "w", 1 ] ]
 
+# 1-regular quivers
+gap> Q1 := 1RegQuivFromCycleLengths( [ 2, 3, 4, 5, 7 ] );
+<quiver with 21 vertices and 21 arrows>
+gap> Is1RegQuiver( Q1 );
+true
+gap> equality := [ ];;
+gap> for v in VerticesOfQuiver( Q1 ) do
+>   Add( equality, 1RegQuivIntAct( v, 420 ) = v );
+> od;
+gap> ForAll(equality, x -> x);
+true
+gap> equality := [ ];;
+gap> for v in VerticesOfQuiver( Q1 ) do
+>   Add( equality, 1RegQuivIntAct( v, 11 ) = v );
+> od;
+gap> ForAny(equality, x -> x);
+false
+
+# 2-regular quivers
+gap> Q2 := 1RegQuivFromCycleLengths( [ 2, 3, 4, 5 ] );
+<quiver with 14 vertices and 14 arrows>
+gap> Is1RegQuiver( Q2 );
+true
+gap> parts := [ ];;
+gap> for k in [ 1 .. NumberOfVertices( Q2 ) / 2 ] do
+>   Add( parts, VerticesOfQuiver( Q2 ){ [ 2 * k - 1, 2 * k ] } );
+> od;
+gap> Q2reg := QuotientQuiver( Q2, parts );
+<quiver with 7 vertices and 14 arrows>
+gap> Is2RegQuiver( Q2reg );
+true
+
 # End test
 gap> STOP_TEST( "sbstrips.tst" );

--- a/tst/testall.tst
+++ b/tst/testall.tst
@@ -347,13 +347,25 @@ gap> Q2 := 1RegQuivFromCycleLengths( [ 2, 3, 4, 5 ] );
 <quiver with 14 vertices and 14 arrows>
 gap> Is1RegQuiver( Q2 );
 true
-gap> parts := [ ];;
+gap> parts1 := [ ];;
+gap> parts2 := [ ];;
+gap> parts3 := [ ];;
 gap> for k in [ 1 .. NumberOfVertices( Q2 ) / 2 ] do
->   Add( parts, VerticesOfQuiver( Q2 ){ [ 2 * k - 1, 2 * k ] } );
+>   Add( parts1, VerticesOfQuiver( Q2 ){ [ 2 * k - 1, 2 * k ] } );
+>   Add( parts2, VerticesOfQuiver( Q2 ){ [ k, NumberOfVertices( Q2 ) - k + 1 ] } );
+>   Add( parts3, VerticesOfQuiver( Q2 ){ [ k, NumberOfVertices( Q2 ) / 2 + k ] } );
 > od;
-gap> Q2reg := QuotientQuiver( Q2, parts );
+gap> Q2reg1 := QuotientQuiver( Q2, parts1 );
 <quiver with 7 vertices and 14 arrows>
-gap> Is2RegQuiver( Q2reg );
+gap> Q2reg2 := QuotientQuiver( Q2, parts2 );
+<quiver with 7 vertices and 14 arrows>
+gap> Q2reg3 := QuotientQuiver( Q2, parts3 );
+<quiver with 7 vertices and 14 arrows>
+gap> Is2RegQuiver( Q2reg1 );
+true
+gap> Is2RegQuiver( Q2reg2 );
+true
+gap> Is2RegQuiver( Q2reg3 );
 true
 
 # End test


### PR DESCRIPTION
Adds functions:
- `1RegQuivFromCycleLengths`
  - Creates 1-regular quivers based on the length of their cycles
  - All 1-regular quivers (up to isomorphism) can be created using this
- `QuiverQuotient`
  - Creates quivers by identifying vertices and keeping arrows between each class 
  - All 2-regular quivers (up to isomorphism) can be created from a 1-regular quiver using this
- `QuiverFilterArrows`
  - Removes arrows from an existing quiver based on an inputted function
  - All sub-2-regular quivers (up to isomorphism) can be created from a 2-regular quiver using this 