### PR TITLE
feat: add method for compression of syllables

### DIFF
--- a/lib/syllables.gd
+++ b/lib/syllables.gd
@@ -11,6 +11,10 @@ DeclareOperation("UnderlyingPathOfSyllable", [IsSyllableRep]);
 DeclareOperation("CompressionOfSyllable", [IsSyllableRep]);
 DeclareOperation("StabilityTermOfSyllable", [IsSyllableRep]);
 
+DeclareOperation("SourceOfSyllable", [IsSyllableRep]);
+DeclareOperation("TargetOfSyllable", [IsSyllableRep]);
+DeclareOperation("LengthOfSyllable", [IsSyllableRep]);
+
 DeclareProperty("IsZeroSyllable", IsSyllableRep);
 DeclareProperty("IsVirtualSyllable", IsSyllableRep);
 DeclareProperty("IsStableSyllable", IsSyllableRep);

--- a/lib/syllables.gd
+++ b/lib/syllables.gd
@@ -8,6 +8,7 @@ DeclareAttribute("ZeroSyllableOfSBAlg", IsSpecialBiserialAlgebra);
 DeclareOperation("Syllabify", [IsPath, IsInt]);
 
 DeclareOperation("UnderlyingPathOfSyllable", [IsSyllableRep]);
+DeclareOperation("CompressionOfSyllable", [IsSyllableRep]);
 DeclareOperation("StabilityTermOfSyllable", [IsSyllableRep]);
 
 DeclareProperty("IsZeroSyllable", IsSyllableRep);

--- a/lib/syllables.gi
+++ b/lib/syllables.gi
@@ -296,6 +296,33 @@ InstallMethod(
 );
 
 InstallMethod(
+    SourceOfSyllable,
+    "for syllables",
+    [IsSyllableRep],
+    function(sy)
+        return SourceOfPath(CompressionOfSyllable(sy));
+    end
+);
+
+InstallMethod(
+    TargetOfSyllable,
+    "for syllables",
+    [IsSyllableRep],
+    function(sy)
+        return TargetOfPath(CompressionOfSyllable(sy));
+    end
+);
+
+InstallMethod(
+    LengthOfSyllable,
+    "for syllables",
+    [IsSyllableRep],
+    function(sy)
+        return LengthOfPath(CompressionOfSyllable(sy));
+    end
+);
+
+InstallMethod(
     IsStableSyllable,
     "for syllables",
     [IsSyllableRep],

--- a/lib/syllables.gi
+++ b/lib/syllables.gi
@@ -270,6 +270,23 @@ InstallMethod(
 );
 
 InstallMethod(
+    CompressionOfSyllable,
+    "for syllables",
+    [IsSyllableRep],
+    function(sy)
+        local s, l;
+
+        if IsZeroSyllable(sy) then
+            return sy!.path;
+        else
+            s := SourceOfPath(sy!.path);
+            l := LengthOfPath(sy!.path) + sy!.stability;
+            return PathBySourceAndLength(s, l);
+        fi;
+    end
+);
+
+InstallMethod(
     StabilityTermOfSyllable,
     "for syllables",
     [IsSyllableRep],

--- a/lib/vertseqs.gi
+++ b/lib/vertseqs.gi
@@ -93,6 +93,7 @@ InstallMethod(
                 Print(",\n");
             fi;
         od;
+        Print("\n");
     end
 );
 


### PR DESCRIPTION
Adds a method for compression of syllables
- if the syllable is interior (stable), then this method returns the underlying path of the syllable.
- if the syllable is boundary (unstable), then this method returns the underlying path of the syllable extended by one arrow at the target